### PR TITLE
fix: Azure blob upload fails with HTTP 400 InvalidMetadata (hyphen in metadata key)

### DIFF
--- a/pkg/backup/storage.go
+++ b/pkg/backup/storage.go
@@ -399,7 +399,7 @@ func (s *S3Storage) Upload(localPath, backupID string) ([]string, error) {
 		Key:    aws.String(key),
 		Body:   file,
 		Metadata: map[string]*string{
-			"backup-id": aws.String(backupID),
+			"backup_id": aws.String(backupID),
 			"uploaded":  aws.String(time.Now().Format(time.RFC3339)),
 		},
 	})
@@ -462,8 +462,8 @@ func (s *S3Storage) List() ([]StoredBackup, error) {
 			if headResult, err := s.client.HeadObject(&s3.HeadObjectInput{
 				Bucket: aws.String(s.bucket),
 				Key:    obj.Key,
-			}); err == nil && headResult.Metadata["backup-id"] != nil {
-				backup.ID = *headResult.Metadata["backup-id"]
+			}); err == nil && headResult.Metadata["backup_id"] != nil {
+				backup.ID = *headResult.Metadata["backup_id"]
 			}
 
 			backups = append(backups, backup)
@@ -552,7 +552,7 @@ func (g *GCSStorage) Upload(localPath, backupID string) ([]string, error) {
 
 	writer := obj.NewWriter(ctx)
 	writer.Metadata = map[string]string{
-		"backup-id": backupID,
+		"backup_id": backupID,
 		"uploaded":  time.Now().Format(time.RFC3339),
 	}
 
@@ -623,8 +623,8 @@ func (g *GCSStorage) List() ([]StoredBackup, error) {
 			StorageType: "gcs",
 		}
 
-		if attrs.Metadata["backup-id"] != "" {
-			backup.ID = attrs.Metadata["backup-id"]
+		if attrs.Metadata["backup_id"] != "" {
+			backup.ID = attrs.Metadata["backup_id"]
 		}
 
 		backups = append(backups, backup)
@@ -703,7 +703,7 @@ func (a *AzureStorage) Upload(localPath, backupID string) ([]string, error) {
 		BlockSize:   4 * 1024 * 1024,
 		Parallelism: 16,
 		Metadata: azblob.Metadata{
-			"backup-id": backupID,
+			"backup_id": backupID,
 			"uploaded":  time.Now().Format(time.RFC3339),
 		},
 	})
@@ -773,8 +773,8 @@ func (a *AzureStorage) List() ([]StoredBackup, error) {
 				StorageType: "azure",
 			}
 
-			if blobInfo.Metadata["backup-id"] != "" {
-				backup.ID = blobInfo.Metadata["backup-id"]
+			if blobInfo.Metadata["backup_id"] != "" {
+				backup.ID = blobInfo.Metadata["backup_id"]
 			}
 
 			backups = append(backups, backup)


### PR DESCRIPTION
## Problem

Azure Blob Storage uploads fail with `HTTP 400 InvalidMetadata` when storage is configured:

```
ServiceCode=InvalidMetadata
Description=The metadata specified is invalid. It has characters that are not permitted.
X-Ms-Meta-Backup-Id: [<call-id>-<timestamp>]
```

Azure requires metadata key names to consist only of alphanumeric characters and underscores. The hyphen in `backup-id` violates this constraint, causing **every Azure upload to fail silently** (warning is logged, but no retry, and `keep_local: false` users lose recordings).

## Fix

Replace `"backup-id"` with `"backup_id"` in all three storage backends (Azure, S3, GCS) for consistency. S3 and GCS technically allow hyphens, but the underscore form is portable across all backends.

Affected lines in `pkg/backup/storage.go`: 402, 465, 466, 555, 626, 627, 706, 776, 777.

## Reproducer

1. Configure Azure Blob Storage (`recording.storage.azure.enabled: true`)
2. Make a SIPREC recording and send BYE
3. Observe in logs: `Failed to upload to storage backend` with `InvalidMetadata`

## Testing

Verified fix with Storage Account `demof9reportsv`, container `siprec` — upload succeeds after patch:
```
Successfully uploaded backup  storage=azure://siprec
locations=[azure://https://demof9reportsv.blob.core.windows.net/siprec/recordings/<file>.wav]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized backup metadata handling across storage providers so backup IDs are now saved and read consistently.
  * Improved backup listing reliability for S3, GCS, and Azure by using a single metadata key format for stored backup IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->